### PR TITLE
- RSAAuthentication and RhostsRSAAuthentication are only used with Pr…

### DIFF
--- a/templates/openssh.conf.j2
+++ b/templates/openssh.conf.j2
@@ -82,11 +82,6 @@ ForwardX11 no
 
 # Never use host-based authentication. It can be exploited.
 HostbasedAuthentication no
-{% if sshd_version.stdout is version('7.6', '<') %}
-RhostsRSAAuthentication no
-# Enable RSA authentication via identity files.
-RSAAuthentication yes
-{% endif %}
 
 # Disable password-based authentication, it can allow for potentially easier brute-force attacks.
 PasswordAuthentication {{ 'yes' if ssh_client_password_login else 'no' }}

--- a/templates/opensshd.conf.j2
+++ b/templates/opensshd.conf.j2
@@ -78,7 +78,7 @@ LogLevel VERBOSE
 {% if sshd_version.stdout is version('7.4', '<') %}
 UseLogin no
 {% endif %}
-{% if sshd_version.stdout is version('7.5', '<') %}
+{% if sshd_version.stdout is version('7.4', '<') %}
 UsePrivilegeSeparation {% if (ansible_distribution == 'Debian' and ansible_distribution_major_version <= '6') or (ansible_os_family in ['Oracle Linux', 'RedHat'] and ansible_distribution_major_version <= '6') -%}{{ssh_ps53}}{% else %}{{ssh_ps59}}{% endif %}
 {% endif %}
 


### PR DESCRIPTION
…otocol=1, and we always force Protocol=2.

- Changed UsePrivilegeScalation (SSH 7.4.1 is already throwing an obsolete-warning). We should consider delete completely the reference to the directive as it’s exclusive of SSHv1 as well.